### PR TITLE
Fix vector property preview

### DIFF
--- a/frontend/src/components/skit/CommandList.tsx
+++ b/frontend/src/components/skit/CommandList.tsx
@@ -5,7 +5,7 @@ import { useDndSortable } from '../../hooks/useDndSortable';
 import { SortableList } from '../dnd/SortableList';
 import { SortableItem } from '../dnd/SortableItem';
 import { DropZone } from '../dnd/DropZone';
-import { SkitCommand, CommandDefinition } from '../../types';
+import { SkitCommand, CommandDefinition, PropertyDefinition } from '../../types';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -130,9 +130,21 @@ export const CommandList = memo(function CommandList() {
     };
     
     Object.entries(commandDef.properties).forEach(([propName, propDefAny]) => {
-      const propDef = propDefAny;
+      const propDef = propDefAny as PropertyDefinition;
       if (propDef.default !== undefined) {
         newCommand[propName] = propDef.default;
+      } else if (
+        propDef.type === 'vector2' ||
+        propDef.type === 'vector2Int'
+      ) {
+        newCommand[propName] = [0, 0];
+      } else if (
+        propDef.type === 'vector3' ||
+        propDef.type === 'vector3Int'
+      ) {
+        newCommand[propName] = [0, 0, 0];
+      } else if (propDef.type === 'vector4') {
+        newCommand[propName] = [0, 0, 0, 0];
       } else if (propDef.required) {
         switch (propDef.type) {
           case 'string':

--- a/frontend/src/components/skit/Toolbar.tsx
+++ b/frontend/src/components/skit/Toolbar.tsx
@@ -57,6 +57,18 @@ export function Toolbar() {
       const propDef = propDefAny as PropertyDefinition;
       if (propDef.default !== undefined) {
         newCommand[propName] = propDef.default;
+      } else if (
+        propDef.type === 'vector2' ||
+        propDef.type === 'vector2Int'
+      ) {
+        newCommand[propName] = [0, 0];
+      } else if (
+        propDef.type === 'vector3' ||
+        propDef.type === 'vector3Int'
+      ) {
+        newCommand[propName] = [0, 0, 0];
+      } else if (propDef.type === 'vector4') {
+        newCommand[propName] = [0, 0, 0, 0];
       } else if (propDef.required) {
         switch (propDef.type) {
           case 'string':


### PR DESCRIPTION
## Summary
- initialize vector property arrays when adding a command
  - ensure vector defaults apply even when property not required
- keep toolbar and context menu consistent

## Testing
- `npm --prefix frontend run lint`
- `npx playwright test --reporter=list` *(fails: connect EHOSTUNREACH)*